### PR TITLE
fix: missing setProperty stub

### DIFF
--- a/media_kit/lib/src/player/native/player/stub.dart
+++ b/media_kit/lib/src/player/native/player/stub.dart
@@ -15,4 +15,10 @@ class NativePlayer extends PlatformPlayer {
   /// Whether the [NativePlayer] is initialized for unit-testing.
   @visibleForTesting
   static bool test = false;
+
+  Future<void> setProperty(
+    String property,
+    String value, {
+    bool waitForInitialization = true,
+  }) async {}
 }


### PR DESCRIPTION
This harmonizes the signature of the `stub.dart` and `real.dart` of both `NativePlayer` and `WebPlayer` as best practice for all its public members potentially used by third party packages (in my case [`just_audio_media_kit` bindings](https://pub.dev/packages/just_audio_media_kit)) or directly by application developers.

I see no potential regressions in it.

Fixes: [#886](https://github.com/media-kit/media-kit/issues/886)