### PR TITLE
chore: refactor mimalloc import

### DIFF
--- a/libs/linux/media_kit_libs_linux/CHANGELOG.md
+++ b/libs/linux/media_kit_libs_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+- chore: refactor mimalloc import
+
 ## 1.1.3
 
 - feat: improve compile-time failure handling

--- a/libs/linux/media_kit_libs_linux/linux/CMakeLists.txt
+++ b/libs/linux/media_kit_libs_linux/linux/CMakeLists.txt
@@ -4,104 +4,120 @@
 # All rights reserved.
 # Use of this source code is governed by MIT license that can be found in the LICENSE file.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 
 # This option is read by the other packages which are part of package:media_kit.
 option(MEDIA_KIT_LIBS_AVAILABLE "package:media_kit libraries are available." ON)
 
+# This is the public option enabling dynamic linking on request of applications.
+option(MIMALLOC_USE_STATIC_LIBS "Whether to prefer linking to mimalloc statically" ON)
+
 set(PROJECT_NAME "media_kit_libs_linux")
 project(${PROJECT_NAME} LANGUAGES CXX)
 
-# We use the mimalloc's object file (mimalloc.o) & link the final executable with it.
-# This ensures that the standard malloc interface resolves to the mimalloc library.
-#
-# Refer to "Static Override" section in mimalloc's documentation:
-# https://github.com/microsoft/mimalloc#static-override
-function(download_and_verify url md5 locationForArchive)
-  # Check if the archive exists.
-  if(EXISTS "${locationForArchive}")
-    file(MD5 "${locationForArchive}" ARCHIVE_MD5)
+if(MIMALLOC_USE_STATIC_LIBS)
 
-    # If MD5 doesn't match, delete the archive to download again.
-    if(NOT md5 STREQUAL ARCHIVE_MD5)
-      file(REMOVE "${locationForArchive}")
-      message(STATUS "MD5 mismatch. File deleted.")
+  # We use the mimalloc's object file (mimalloc.o) & link the final executable with it.
+  # This ensures that the standard malloc interface resolves to the mimalloc library.
+  #
+  # Refer to "Static Override" section in mimalloc's documentation:
+  # https://github.com/microsoft/mimalloc#static-override
+  function(download_and_verify url md5 locationForArchive)
+    # Check if the archive exists.
+    if(EXISTS "${locationForArchive}")
+      file(MD5 "${locationForArchive}" ARCHIVE_MD5)
+
+      # If MD5 doesn't match, delete the archive to download again.
+      if(NOT md5 STREQUAL ARCHIVE_MD5)
+        file(REMOVE "${locationForArchive}")
+        message(STATUS "MD5 mismatch. File deleted.")
+      endif()
     endif()
-  endif()
 
-  # Download the archive if it doesn't exist.
-  if(NOT EXISTS "${locationForArchive}")
-    message(STATUS "Downloading archive from ${url}...")
-    file(DOWNLOAD "${url}" "${locationForArchive}")
-    message(STATUS "Downloaded archive to ${locationForArchive}.")
+    # Download the archive if it doesn't exist.
+    if(NOT EXISTS "${locationForArchive}")
+      message(STATUS "Downloading archive from ${url}...")
+      file(DOWNLOAD "${url}" "${locationForArchive}")
+      message(STATUS "Downloaded archive to ${locationForArchive}.")
 
-    # Verify MD5 of the newly downloaded file.
-    file(MD5 "${locationForArchive}" ARCHIVE_MD5)
+      # Verify MD5 of the newly downloaded file.
+      file(MD5 "${locationForArchive}" ARCHIVE_MD5)
 
-    if(md5 STREQUAL ARCHIVE_MD5)
-      message(STATUS "${locationForArchive} Verification successful.")
-    else()
-      message(FATAL_ERROR "${locationForArchive} Integrity check failed, please try to rebuild project again.")
+      if(md5 STREQUAL ARCHIVE_MD5)
+        message(STATUS "${locationForArchive} Verification successful.")
+      else()
+        message(FATAL_ERROR "${locationForArchive} Integrity check failed, please try to rebuild project again.")
+      endif()
     endif()
-  endif()
-endfunction()
+  endfunction()
 
-# ------------------------------------------------------------------------------
-set(MIMALLOC "mimalloc-2.1.2.tar.gz")
+  # ------------------------------------------------------------------------------
+  set(MIMALLOC "mimalloc-2.1.2.tar.gz")
 
-set(MIMALLOC_URL "https://github.com/microsoft/mimalloc/archive/refs/tags/v2.1.2.tar.gz")
-set(MIMALLOC_MD5 "5179c8f5cf1237d2300e2d8559a7bc55")
+  set(MIMALLOC_URL "https://github.com/microsoft/mimalloc/archive/refs/tags/v2.1.2.tar.gz")
+  set(MIMALLOC_MD5 "5179c8f5cf1237d2300e2d8559a7bc55")
 
-set(MIMALLOC_ARCHIVE "${CMAKE_BINARY_DIR}/${MIMALLOC}")
-set(MIMALLOC_SRC "${CMAKE_BINARY_DIR}/mimalloc")
+  set(MIMALLOC_ARCHIVE "${CMAKE_BINARY_DIR}/${MIMALLOC}")
+  set(MIMALLOC_SRC "${CMAKE_BINARY_DIR}/mimalloc")
 
-download_and_verify(
-  ${MIMALLOC_URL}
-  ${MIMALLOC_MD5}
-  ${MIMALLOC_ARCHIVE}
-)
+  download_and_verify(
+    ${MIMALLOC_URL}
+    ${MIMALLOC_MD5}
+    ${MIMALLOC_ARCHIVE}
+  )
 
-function(check_directory_exists_and_not_empty dir result_var)
-  # Check if the directory exists
-  if(EXISTS "${dir}")
-    # Check if the directory is not empty
-    file(GLOB dir_contents "${dir}/*")
+  function(check_directory_exists_and_not_empty dir result_var)
+    # Check if the directory exists
+    if(EXISTS "${dir}")
+      # Check if the directory is not empty
+      file(GLOB dir_contents "${dir}/*")
 
-    if(dir_contents)
-      set(${result_var} TRUE PARENT_SCOPE)
+      if(dir_contents)
+        set(${result_var} TRUE PARENT_SCOPE)
+      else()
+        set(${result_var} FALSE PARENT_SCOPE)
+        message(STATUS "Directory ${dir} exists but is empty!")
+      endif()
     else()
       set(${result_var} FALSE PARENT_SCOPE)
-      message(STATUS "Directory ${dir} exists but is empty!")
+      message(STATUS "Directory ${dir} does not exist!")
     endif()
-  else()
-    set(${result_var} FALSE PARENT_SCOPE)
-    message(STATUS "Directory ${dir} does not exist!")
+  endfunction()
+
+  # Extract
+  # https://stackoverflow.com/a/19859882/12825435
+  set(MIMALLOC_LIB "${MIMALLOC_SRC}/out/release/mimalloc.o" CACHE INTERNAL "")
+
+  check_directory_exists_and_not_empty(${MIMALLOC_SRC} MIMALLOC_VALID)
+
+  if(NOT MIMALLOC_VALID)
+    message(STATUS "Extracting ${MIMALLOC}...")
+    make_directory("${MIMALLOC_SRC}")
+    add_custom_command(
+      OUTPUT ${MIMALLOC_LIB}
+      COMMAND "${CMAKE_COMMAND}" -E tar xzf "${MIMALLOC_ARCHIVE}"
+
+      # add_subdirectory() is too much work. Alternatively building it through command line.
+      COMMAND "mkdir" "-p" "out/release"
+      COMMAND "cd" "out/release"
+      COMMAND "${CMAKE_COMMAND}" "../../mimalloc-2.1.2"
+      COMMAND "make"
+      WORKING_DIRECTORY "${MIMALLOC_SRC}"
+    )
   endif()
-endfunction()
 
-# Extract
-# https://stackoverflow.com/a/19859882/12825435
-set(MIMALLOC_LIB "${MIMALLOC_SRC}/out/release/mimalloc.o" CACHE INTERNAL "")
+  add_custom_target("MIMALLOC_TARGET" ALL DEPENDS ${MIMALLOC_LIB})
 
-check_directory_exists_and_not_empty(${MIMALLOC_SRC} MIMALLOC_VALID)
+else()
 
-if(NOT MIMALLOC_VALID)
-  message(STATUS "Extracting ${MIMALLOC}...")
-  make_directory("${MIMALLOC_SRC}")
-  add_custom_command(
-    OUTPUT ${MIMALLOC_LIB}
-    COMMAND "${CMAKE_COMMAND}" -E tar xzf "${MIMALLOC_ARCHIVE}"
+  find_library(MIMALLOC_PATH "libmimalloc.so")
+  if(MIMALLOC_PATH)
+    set(MIMALLOC_LIB "${MIMALLOC_PATH}" CACHE INTERNAL "")
+  endif()
 
-    # add_subdirectory() is too much work. Alternatively building it through command line.
-    COMMAND "mkdir" "-p" "out/release"
-    COMMAND "cd" "out/release"
-    COMMAND "${CMAKE_COMMAND}" "../../mimalloc-2.1.2"
-    COMMAND "make"
-    WORKING_DIRECTORY "${MIMALLOC_SRC}"
-  )
 endif()
 
-add_custom_target("MIMALLOC_TARGET" ALL DEPENDS ${MIMALLOC_LIB})
+unset(MIMALLOC_USE_STATIC_LIBS CACHE)
 
 # ------------------------------------------------------------------------------
 set(PLUGIN_NAME "media_kit_libs_linux_plugin")

--- a/libs/linux/media_kit_libs_linux/pubspec.yaml
+++ b/libs/linux/media_kit_libs_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: media_kit_libs_linux
 description: GNU/Linux dependency package for package:media_kit. Necessary for initialization.
-version: 1.1.3
+version: 1.2.0
 homepage: https://github.com/media-kit/media-kit.git
 repository: https://github.com/media-kit/media-kit.git
 

--- a/media_kit/README.md
+++ b/media_kit/README.md
@@ -1664,6 +1664,7 @@ There are other ways to bundle these within your app package e.g. within Snap or
 - [Celluloid](https://github.com/celluloid-player/celluloid/blob/master/flatpak/io.github.celluloid_player.Celluloid.json)
 - [VidCutter](https://github.com/ozmartian/vidcutter/tree/master/_packaging)
 
+
 #### Utilize [mimalloc](https://github.com/microsoft/mimalloc)
 
 You should consider replacing the default memory allocator with [mimalloc](https://github.com/microsoft/mimalloc) for [avoiding memory leaks](https://github.com/media-kit/media-kit/issues/68).
@@ -1672,6 +1673,21 @@ This is as simple as [adding one line to `linux/CMakeLists.txt`](https://github.
 
 ```cmake
 target_link_libraries(${BINARY_NAME} PRIVATE ${MIMALLOC_LIB})
+```
+
+In case you prefer dynamic linking of mimalloc, you can additionally add the following line to your `linux/CMakeLists.txt`:
+
+```cmake
+# use dynamically linked mimalloc
+set(MIMALLOC_USE_STATIC_LIBS OFF)
+```
+
+In this case, please ensure you install `libmimalloc-dev` at compile time and `libmimalloc2.0` as runtime dependencies.
+
+#### Ubuntu/Debian
+
+```bash
+sudo apt install libmimalloc-dev libmimalloc2.0
 ```
 
 ### Web


### PR DESCRIPTION
In some cases, users of the plugin might prefer to use a dynamically linked version of mimalloc. This PR introduces a new CMake option allowing to dynamically link mimalloc. Unlike [#883](https://github.com/media-kit/media-kit/pull/883) , this PR does **not** change the default behavior but simply adds an additional CMake option.

**The default behavior of the plugin is not changed.**

If users set the CMake option :

```cmake
set(MIMALLOC_USE_STATIC_LIBS OFF)
```

This plugin will now link against the system-provided mimalloc.

Users might prefer this in case they try to reduce installation size or aim to comply with distributor-specific dependency management requirements.

Unless this option is set to `OFF`, the behavior of the plugin won't change.

Thanks a lot for your amazing work 🎉 !

- chore: refactor mimalloc import
- fix: correct minimum required CMake version
- chore: better format if statement