### PR TITLE
Support Windows ARM64 libmpv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,39 @@ jobs:
           files: |
             media_kit_test/media_kit_test_win32_x64.7z
 
+  windows-arm64:
+    name: Windows ARM64
+    runs-on: windows-11-arm
+    defaults:
+      run:
+        working-directory: media_kit_test
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: "true"
+      - name: Set up Flutter for ARM64
+        shell: pwsh
+        run: |
+          $flutterPath = Join-Path $env:RUNNER_TEMP "flutter"
+          git clone https://github.com/flutter/flutter.git -b stable --depth 1 $flutterPath
+          Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $flutterPath "bin")
+          & (Join-Path $flutterPath "bin\flutter.bat") --version
+      - run: flutter pub get
+      - run: flutter build windows --verbose
+      - run: cmake -E tar "cfv" "media_kit_test_win32_arm64.7z" --format=7zip "build\windows\arm64\runner\Release"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: media_kit_test_win32_arm64
+          path: media_kit_test/media_kit_test_win32_arm64.7z
+      - uses: softprops/action-gh-release@v1
+        if: github.ref == 'refs/heads/main'
+        with:
+          draft: true
+          prerelease: false
+          tag_name: "vnext"
+          files: |
+            media_kit_test/media_kit_test_win32_arm64.7z
+
   linux:
     name: Linux
     runs-on: ubuntu-latest

--- a/libs/windows/media_kit_libs_windows_video/windows/CMakeLists.txt
+++ b/libs/windows/media_kit_libs_windows_video/windows/CMakeLists.txt
@@ -68,17 +68,15 @@ string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" LIBMPV_TARGET_PROCESSOR)
 string(TOLOWER "${CMAKE_GENERATOR_PLATFORM}" LIBMPV_GENERATOR_PLATFORM)
 
 if(LIBMPV_TARGET_PROCESSOR MATCHES "^(arm64|aarch64)$" OR LIBMPV_GENERATOR_PLATFORM MATCHES "^(arm64|aarch64)$")
-  set(LIBMPV_TARGET_ARM64 TRUE)
-  set(LIBMPV "mpv-dev-aarch64-20251210-git-ad59ff1.7z")
-  set(LIBMPV_SHA256 "8e3746e9d88351dd19be0e0da0c8745a089a3d07d5dd8a84c10de7f47ba88bcd")
+  set(LIBMPV "mpv-dev-aarch64-20260623-git-ad59ff1.zip")
+  set(LIBMPV_SHA256 "381711758315b81d17df24fbb9dc4333b33b840c14fd674e264fb3306d21b7b0")
 else()
-  set(LIBMPV_TARGET_ARM64 FALSE)
-  set(LIBMPV "mpv-dev-x86_64-20251210-git-ad59ff1.7z")
-  set(LIBMPV_SHA256 "53212bb8886d76d041ecd023a29e6213ada6fb5afedb8970610b396435833b99")
+  set(LIBMPV "mpv-dev-x86_64-20260623-git-ad59ff1.7z")
+  set(LIBMPV_SHA256 "159d7379898e2e2490ab3e0dca233daa5b7389fcd32d4cb8c420399f44284399")
 endif()
 
 # Download URL of the libmpv archive.
-set(LIBMPV_URL "https://github.com/Predidit/libmpv-win32-video-cmake/releases/download/20251210/${LIBMPV}")
+set(LIBMPV_URL "https://github.com/Predidit/libmpv-win32-video-cmake/releases/download/20260623/${LIBMPV}")
 
 # Download location of the libmpv archive.
 set(LIBMPV_ARCHIVE "${CMAKE_BINARY_DIR}/${LIBMPV}")
@@ -97,33 +95,14 @@ if(NOT LIBMPV_SRC_VALID)
   message(STATUS "Extracting ${LIBMPV}...")
   make_directory("${LIBMPV_SRC}")
   add_custom_target("${PROJECT_NAME}_LIBMPV_EXTRACT" ALL)
-  if(LIBMPV_TARGET_ARM64)
-    # CMake's built-in extractor cannot unpack the current aarch64 .7z asset
-    # on Windows ARM64 ("Unexpected codec ID: a"), so use 7-Zip for this archive.
-    find_program(LIBMPV_7Z_EXECUTABLE NAMES 7z 7za 7zr)
-
-    if(NOT LIBMPV_7Z_EXECUTABLE)
-      message(FATAL_ERROR "7z is required to extract ${LIBMPV}.")
-    endif()
-
-    add_custom_command(
-      TARGET "${PROJECT_NAME}_LIBMPV_EXTRACT"
-      COMMAND "${LIBMPV_7Z_EXECUTABLE}" x "${LIBMPV_ARCHIVE}" -y
-      COMMAND xcopy "\"${LIBMPV_SRC}/include/mpv\"" "\"${LIBMPV_SRC}/mpv\"" /E /H /C /I
-      COMMAND rmdir "\"${LIBMPV_SRC}/include\"" /S /Q
-      COMMAND ren "\"${LIBMPV_SRC}/mpv\"" "\"include\""
-      WORKING_DIRECTORY "${LIBMPV_SRC}"
-    )
-  else()
-    add_custom_command(
-      TARGET "${PROJECT_NAME}_LIBMPV_EXTRACT"
-      COMMAND "${CMAKE_COMMAND}" -E tar xzf "\"${LIBMPV_ARCHIVE}\""
-      COMMAND xcopy "\"${LIBMPV_SRC}/include/mpv\"" "\"${LIBMPV_SRC}/mpv\"" /E /H /C /I
-      COMMAND rmdir "\"${LIBMPV_SRC}/include\"" /S /Q
-      COMMAND ren "\"${LIBMPV_SRC}/mpv\"" "\"include\""
-      WORKING_DIRECTORY "${LIBMPV_SRC}"
-    )
-  endif()
+  add_custom_command(
+    TARGET "${PROJECT_NAME}_LIBMPV_EXTRACT"
+    COMMAND "${CMAKE_COMMAND}" -E tar xzf "\"${LIBMPV_ARCHIVE}\""
+    COMMAND xcopy "\"${LIBMPV_SRC}/include/mpv\"" "\"${LIBMPV_SRC}/mpv\"" /E /H /C /I
+    COMMAND rmdir "\"${LIBMPV_SRC}/include\"" /S /Q
+    COMMAND ren "\"${LIBMPV_SRC}/mpv\"" "\"include\""
+    WORKING_DIRECTORY "${LIBMPV_SRC}"
+  )
 endif()
 
 # ------------------------------------------------------------------------------

--- a/libs/windows/media_kit_libs_windows_video/windows/CMakeLists.txt
+++ b/libs/windows/media_kit_libs_windows_video/windows/CMakeLists.txt
@@ -64,11 +64,21 @@ function(check_directory_exists_and_not_empty dir result_var)
 endfunction()
 
 # libmpv archive containing the pre-built shared libraries & headers.
-set(LIBMPV "mpv-dev-x86_64-20251210-git-ad59ff1.7z")
+string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" LIBMPV_TARGET_PROCESSOR)
+string(TOLOWER "${CMAKE_GENERATOR_PLATFORM}" LIBMPV_GENERATOR_PLATFORM)
 
-# Download URL & SHA256 hash of the libmpv archive.
+if(LIBMPV_TARGET_PROCESSOR MATCHES "^(arm64|aarch64)$" OR LIBMPV_GENERATOR_PLATFORM MATCHES "^(arm64|aarch64)$")
+  set(LIBMPV_TARGET_ARM64 TRUE)
+  set(LIBMPV "mpv-dev-aarch64-20251210-git-ad59ff1.7z")
+  set(LIBMPV_SHA256 "8e3746e9d88351dd19be0e0da0c8745a089a3d07d5dd8a84c10de7f47ba88bcd")
+else()
+  set(LIBMPV_TARGET_ARM64 FALSE)
+  set(LIBMPV "mpv-dev-x86_64-20251210-git-ad59ff1.7z")
+  set(LIBMPV_SHA256 "53212bb8886d76d041ecd023a29e6213ada6fb5afedb8970610b396435833b99")
+endif()
+
+# Download URL of the libmpv archive.
 set(LIBMPV_URL "https://github.com/Predidit/libmpv-win32-video-cmake/releases/download/20251210/${LIBMPV}")
-set(LIBMPV_SHA256 "53212bb8886d76d041ecd023a29e6213ada6fb5afedb8970610b396435833b99")
 
 # Download location of the libmpv archive.
 set(LIBMPV_ARCHIVE "${CMAKE_BINARY_DIR}/${LIBMPV}")
@@ -87,14 +97,33 @@ if(NOT LIBMPV_SRC_VALID)
   message(STATUS "Extracting ${LIBMPV}...")
   make_directory("${LIBMPV_SRC}")
   add_custom_target("${PROJECT_NAME}_LIBMPV_EXTRACT" ALL)
-  add_custom_command(
-    TARGET "${PROJECT_NAME}_LIBMPV_EXTRACT"
-    COMMAND "${CMAKE_COMMAND}" -E tar xzf "\"${LIBMPV_ARCHIVE}\""
-    COMMAND xcopy "\"${LIBMPV_SRC}/include/mpv\"" "\"${LIBMPV_SRC}/mpv\"" /E /H /C /I
-    COMMAND rmdir "\"${LIBMPV_SRC}/include\"" /S /Q
-    COMMAND ren "\"${LIBMPV_SRC}/mpv\"" "\"include\""
-    WORKING_DIRECTORY "${LIBMPV_SRC}"
-  )
+  if(LIBMPV_TARGET_ARM64)
+    # CMake's built-in extractor cannot unpack the current aarch64 .7z asset
+    # on Windows ARM64 ("Unexpected codec ID: a"), so use 7-Zip for this archive.
+    find_program(LIBMPV_7Z_EXECUTABLE NAMES 7z 7za 7zr)
+
+    if(NOT LIBMPV_7Z_EXECUTABLE)
+      message(FATAL_ERROR "7z is required to extract ${LIBMPV}.")
+    endif()
+
+    add_custom_command(
+      TARGET "${PROJECT_NAME}_LIBMPV_EXTRACT"
+      COMMAND "${LIBMPV_7Z_EXECUTABLE}" x "${LIBMPV_ARCHIVE}" -y
+      COMMAND xcopy "\"${LIBMPV_SRC}/include/mpv\"" "\"${LIBMPV_SRC}/mpv\"" /E /H /C /I
+      COMMAND rmdir "\"${LIBMPV_SRC}/include\"" /S /Q
+      COMMAND ren "\"${LIBMPV_SRC}/mpv\"" "\"include\""
+      WORKING_DIRECTORY "${LIBMPV_SRC}"
+    )
+  else()
+    add_custom_command(
+      TARGET "${PROJECT_NAME}_LIBMPV_EXTRACT"
+      COMMAND "${CMAKE_COMMAND}" -E tar xzf "\"${LIBMPV_ARCHIVE}\""
+      COMMAND xcopy "\"${LIBMPV_SRC}/include/mpv\"" "\"${LIBMPV_SRC}/mpv\"" /E /H /C /I
+      COMMAND rmdir "\"${LIBMPV_SRC}/include\"" /S /Q
+      COMMAND ren "\"${LIBMPV_SRC}/mpv\"" "\"include\""
+      WORKING_DIRECTORY "${LIBMPV_SRC}"
+    )
+  endif()
 endif()
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR is part of the work to add Windows on ARM packaging support for Kazumi (Predidit/Kazumi#1008).

It adds Windows ARM64 support to `media_kit_libs_windows_video`. When CMake targets ARM64, the package now uses the aarch64 libmpv archive. Other Windows builds keep using the existing x64 archive and extraction path.

## Changes

- Detect Windows ARM64 from `CMAKE_SYSTEM_PROCESSOR` and `CMAKE_GENERATOR_PLATFORM`.
- Use `mpv-dev-aarch64-20251210-git-ad59ff1.7z` for ARM64 builds.
- Keep `mpv-dev-x86_64-20251210-git-ad59ff1.7z` unchanged for x64 builds.
- Use 7-Zip to extract the ARM64 archive.
- Add a Windows ARM64 CI job that builds `media_kit_test` on `windows-11-arm`.

The x64 archive still uses the existing CMake extraction path. 7-Zip is only used for the ARM64 archive because CMake's built-in extractor fails on that `.7z` file on Windows ARM64:

```text
Unexpected codec ID: a
```

## Validation

I validated this by pinning Kazumi to this media-kit commit in a fork and running the Windows ARM64 build there.

- `flutter build windows` completed on GitHub's Windows ARM64 runner.
- The build produced an ARM64 Windows zip package.
- The package was tested locally on a Windows on ARM machine.

Validation run:
https://github.com/NihilDigit/Kazumi/actions/runs/27873267299

This PR also adds a native Windows ARM64 CI build for `media_kit_test`.
